### PR TITLE
feat: add option newTranslationTargetsBlank

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ npm run extract-i18n-merge
 
 In your `angular.json` you'll find a new target `extract-i18n-merge` that can be configured with the following options:
 
-| Name                    | Default                                 | Description                                                                                                                                                                 |
-|-------------------------|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `format`                | Inferred from current setup by `ng add` | Any of `xlf`, `xlif`, `xliff`, `xlf2`, `xliff2`                                                                                                                             |
-| `outputPath`            | Inferred from current setup by `ng add` | Path to folder containing all (source and target) translation files.                                                                                                        |
-| `targetFiles`           | Inferred from current setup by `ng add` | Filenames (relative to `outputPath` of all target translation files (e.g. `["messages.fr.xlf", "messages.de.xlf"]`                                                          |
-| `removeIdsWithPrefix`   | `[]`                                    | List of prefix strings. All translation units with matching `id` attribute are removed. Useful for excluding duplicate library translations.                                |
-| `fuzzyMatch`            | `true`                                  | Whether translation units without matching IDs are fuzzy matched by source text.                                                                                            |
-| `resetTranslationState` | `true`                                  | Reset the translation state to new/initial for new/changed units.                                                                                                           |
-| `collapseWhitespace`    | `true`                                  | Collapsing of multiple whitespaces and trimming when comparing translations sources.                                                                                        |
-| `includeContext`        | `false`                                 | Whether to include the context information (like notes) in the translation files. This is useful for sending the target translation files to translation agencies/services. |
+| Name                         | Default                                 | Description                                                                                                                                                                 |
+|------------------------------|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `format`                     | Inferred from current setup by `ng add` | Any of `xlf`, `xlif`, `xliff`, `xlf2`, `xliff2`                                                                                                                             |
+| `outputPath`                 | Inferred from current setup by `ng add` | Path to folder containing all (source and target) translation files.                                                                                                        |
+| `targetFiles`                | Inferred from current setup by `ng add` | Filenames (relative to `outputPath` of all target translation files (e.g. `["messages.fr.xlf", "messages.de.xlf"]`                                                          |
+| `removeIdsWithPrefix`        | `[]`                                    | List of prefix strings. All translation units with matching `id` attribute are removed. Useful for excluding duplicate library translations.                                |
+| `fuzzyMatch`                 | `true`                                  | Whether translation units without matching IDs are fuzzy matched by source text.                                                                                            |
+| `resetTranslationState`      | `true`                                  | Reset the translation state to new/initial for new/changed units.                                                                                                           |
+| `collapseWhitespace`         | `true`                                  | Collapsing of multiple whitespaces and trimming when comparing translations sources.                                                                                        |
+| `includeContext`             | `false`                                 | Whether to include the context information (like notes) in the translation files. This is useful for sending the target translation files to translation agencies/services. |
+| `newTranslationTargetsBlank` | `false`                                 | When `false` (default) the "target" of new translation units is set to the "source" value. When `true` an empty string is used.                                             |
 
 ## Contribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3536,9 +3536,9 @@
       "dev": true
     },
     "xliff-simple-merge": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/xliff-simple-merge/-/xliff-simple-merge-0.8.2.tgz",
-      "integrity": "sha512-LIhqmRxfKbIvy9UwBlsb8Lv4lfXKDCw9wNMke7nySZ5CgtekMaJJWDbmQafU46M9kY60B5+J3sVpZvfYXDJq8w==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/xliff-simple-merge/-/xliff-simple-merge-0.9.1.tgz",
+      "integrity": "sha512-JzlXWVwdQMTjWICORua53p4tT9mrLDWM6nB5QWiOSZa3elPAb4fVw937li/mvz6Oa+GoH8DRJhUAdtsiLzW4ug==",
       "requires": {
         "commander": "~8.3.0",
         "js-levenshtein": "~1.1.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular-devkit/core": "^13.0.0",
     "@angular-devkit/schematics": "^13.0.0",
     "@schematics/angular": "^13.0.0",
-    "xliff-simple-merge": "~0.8.2",
+    "xliff-simple-merge": "~0.9.1",
     "xml_normalize": "~0.8.2"
   },
   "devDependencies": {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -12,7 +12,8 @@ interface Options extends JsonObject {
     fuzzyMatch: boolean,
     resetTranslationState: boolean,
     collapseWhitespace: boolean,
-    includeContext: boolean
+    includeContext: boolean,
+    newTranslationTargetsBlank: boolean,
 }
 
 export default createBuilder(copyFileBuilder);

--- a/src/schema.json
+++ b/src/schema.json
@@ -36,6 +36,11 @@
       "default": true,
       "description": "Reset the translation state to new/initial for new/changed units."
     },
+    "newTranslationTargetsBlank": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set target for new translation units to empty string (instead of original source)."
+    },
     "collapseWhitespace": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
This new option allows toggling whether targets of new translation units are created empty or with the source value.