### PR TITLE
New feature: Manage translation files by module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 examples
 coverage
 builder-test/*.xlf
+pack

--- a/README.md
+++ b/README.md
@@ -27,12 +27,80 @@ Breaking changes:
 * Default sort is now "stableAppendNew" (was: "idAsc") (#26).
 * Leading/trailing whitespaces are normalized (i.e. collapsed to one space) but not completely trimmed (#28).
 * Npm run script is removed (you can create a manual npm run script of course).
+* Now you can manage big translation file by modules
 
 ## Usage
 
 ```shell
 ng extract-i18n # yes, same as before - this replaces the original builder
 ```
+
+### Manage by module
+
+Assume this is an international project, and we need support in multiple languages. 
+By then, the translation files had scaled up the size and were hard to manage. This is the translation management by 
+modules that show its power.
+
+```shell
+ng assemble-i18n
+```
+
+In your project.json or angular.json, add `manageModules` and `assemble-i18n` if they does not exist
+```json
+ "assemble-i18n": {
+      "executor": "ng-extract-i18n-merge:ng-extract-i18n-assemble",
+      "options": {
+        "browserTarget": "item-portal:build",
+        "format": "xlf2",
+        "outputPath": "src/assets/i18n",
+        "sourceFile": "messages.xlf",
+        "manageModules": true,
+        "targetFiles": [
+          "messages.en.xlf",
+          "messages.da.xlf"
+        ]
+      }
+    },
+    "extract-i18n": {
+      "executor": "ng-extract-i18n-merge:ng-extract-i18n-merge",
+      "options": {
+        "browserTarget": "item-portal:build",
+        "format": "xlf2",
+        "outputPath": "src/assets/i18n",
+        "sourceFile": "messages.xlf",
+        "manageModules": true,
+        "targetFiles": [
+          "messages.en.xlf",
+          "messages.da.xlf"
+        ]
+      }
+    },
+```
+
+When you run `nx extract-i18n`, base on your `@@moduleId_UnitId`
+For example: If the unit id in html is `@@Frame_FrameDetails`, `@@Setting_Location` and `@@Common_Delete` you will got files like this
+```
+.
+├── message.xlf
+├── message.en.xlf
+├── message.da.xlf
+├── frame/
+│   ├── frame.en.xlf
+│   └── frame.da.xlf
+├── setting/
+│   ├── setting.en.xlf
+│   └── setting.da.xlf
+└── common/
+    ├── common.en.xlf
+    └── common.da.xlf
+```
+
+Send your parts to the translation department, then execute combine them by command
+to assemble only
+```shell
+nx assemble-i18n
+```
+Or ```nx extract-i18n``` to extract and assemble at the same time.
 
 ### Configuration
 
@@ -43,6 +111,7 @@ In your `angular.json` the target `extract-i18n` that can be configured with the
 | `browserTarget`              | Inferred from current setup by `ng add`                     | A browser builder target to extract i18n messages in the format of `project:target[:configuration]`. See https://angular.io/cli/extract-i18n#options                                                                                                |
 | `format`                     | Inferred from current setup by `ng add`                     | Any of `xlf`, `xlif`, `xliff`, `xlf2`, `xliff2`                                                                                                                                                                                                     |
 | `outputPath`                 | Inferred from current setup by `ng add`                     | Path to folder containing all (source and target) translation files.                                                                                                                                                                                |
+| `manageModules`              | `false`                                                     | Divide translation files to multiple file base on id. (e.g. `["/module1/module1.fr.xlf", "module2/module2.fr.xlf"]`).                                                                                                                               |
 | `targetFiles`                | Inferred from current setup by `ng add`                     | Filenames (relative to `outputPath` of all target translation files (e.g. `["messages.fr.xlf", "messages.de.xlf"]`).                                                                                                                                |
 | `sourceLanguageTargetFile`   | Unused                                                      | If this is set (to one of the `targetFiles`), new translations in that target file will be set to `state="final"` (instead of default `state="new"`).                                                                                               |
 | `sourceFile`                 | `messages.xlf`. `ng add` tries to infer non default setups. | Filename (relative to `outputPath` of source translation file (e.g. `"translations-source.xlf"`).                                                                                                                                                   |

--- a/builders.json
+++ b/builders.json
@@ -4,6 +4,11 @@
       "implementation": "./dist/src/builder.js",
       "schema": "./src/schema.json",
       "description": "Extract and merge i18n translation units"
+    },
+    "ng-extract-i18n-assemble": {
+      "implementation": "./dist/src/assemble.js",
+      "schema": "./src/schema.json",
+      "description": "Assemble modules file to target file"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc",
     "prepack": "tsc",
+    "pack": "npm run prepack && node packer.js",
     "test": "jest",
     "test-coverage": "jest --coverage"
   },

--- a/packer.js
+++ b/packer.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const path = require("path");
+function createDirIfNotExist(dir) {
+    if (!fs.existsSync(dir)){
+        fs.mkdirSync(dir, { recursive: true });
+    }
+}
+
+function copyFileSync( source, target ) {
+    let targetFile = target;
+    // If target is a directory, a new file with the same name will be created
+    if ( fs.existsSync( target ) ) {
+        if ( fs.lstatSync( target ).isDirectory() ) {
+            targetFile = path.join( target, path.basename( source ) );
+        }
+    }
+    fs.writeFileSync(targetFile, fs.readFileSync(source));
+}
+
+function copyFolderRecursiveSync( source, target ) {
+    let files = [];
+
+    // Check if folder needs to be created or integrated
+    const targetFolder = path.join( target, path.basename( source ) );
+    createDirIfNotExist(targetFolder);
+
+    // Copy
+    if ( fs.lstatSync( source ).isDirectory() ) {
+        files = fs.readdirSync( source );
+        files.forEach( function ( file ) {
+            var curSource = path.join( source, file );
+            if ( fs.lstatSync( curSource ).isDirectory() ) {
+                copyFolderRecursiveSync( curSource, targetFolder );
+            } else {
+                copyFileSync( curSource, targetFolder );
+            }
+        } );
+    }
+}
+
+fs.rmSync("pack", { recursive: true, force: true });
+createDirIfNotExist("pack/src");
+createDirIfNotExist("pack/schematics/ng-add");
+createDirIfNotExist("pack/schematics/migrations");
+
+copyFolderRecursiveSync("dist/src", "pack/dist");
+copyFolderRecursiveSync("dist/schematics", "pack/dist");
+fs.copyFileSync("src/schema.json", "pack/src/schema.json");
+fs.copyFileSync("schematics/collection.json", "pack/schematics/collection.json");
+fs.copyFileSync("schematics/ng-add/schema.json", "pack/schematics/ng-add/schema.json");
+fs.copyFileSync("schematics/migrations/migrations.json", "pack/schematics/migrations/migrations.json");
+fs.copyFileSync("LICENSE.txt", "pack/LICENSE.txt");
+fs.copyFileSync("README.md", "pack/README.md");
+fs.copyFileSync("package.json", "pack/package.json");
+fs.copyFileSync("builders.json", "pack/builders.json");

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -114,6 +114,19 @@ export function ngAdd(_options: Schema): Rule {
                     options: builderOptions,
                 });
             }
+
+            const target2 = projectWorkspace.targets.get('assemble-i18n');
+            if (target2) {
+                context.logger.info(`Overwriting previous assemble-i18n entry in project ${projectName}.`);
+                target2.builder = 'ng-extract-i18n-merge:ng-extract-i18n-assemble';
+                target2.options = builderOptions;
+            } else {
+                projectWorkspace.targets.add({
+                    name: 'assemble-i18n',
+                    builder: 'ng-extract-i18n-merge:ng-extract-i18n-assemble',
+                    options: builderOptions,
+                });
+            }
         });
     };
 }

--- a/src/assemble.ts
+++ b/src/assemble.ts
@@ -1,0 +1,95 @@
+import {join, normalize} from '@angular-devkit/core';
+import {Options} from './builder';
+import {getAllFileInDir, readFileIfExists} from "./fileUtils";
+import {BuilderContext, BuilderOutput, createBuilder} from '@angular-devkit/architect';
+import {promises as fs } from 'fs';
+import {xmlNormalize} from 'xml_normalize/dist/src/xmlNormalize';
+import {XmlDocument, XmlNode} from 'xmldoc';
+import {Evaluator} from 'xml_normalize/dist/src/xpath/simpleXPath';
+
+const builder: ReturnType<typeof createBuilder> = createBuilder(extractI18nAssembleBuilder);
+export default builder;
+
+/**
+ * Assemble the modules files and combine them to message.locale.xlf file
+ * @param moduleFilePaths the @id/module.en.xlf file
+ * @param targetFilePath  the message.en.xlf file
+ * @param idPath the path to get message id, it depends on xliff v1 or v2
+ * @param options builder option - follow schema.json
+ * @param context builder context
+ */
+async function mirgateModuleFileToTargetFile(moduleFilePaths: string[], targetFilePath: string, idPath: string, options: Options, context: BuilderContext): Promise<string> {
+    const targetFileContent = await readFileIfExists(targetFilePath);
+    if (!options.manageModules) throw new Error("Not enable manage by modules yet, please enable in project configuration");
+    if (!targetFileContent) throw new Error("The targetFilePath is not exist");
+    const targetFileDoc = new XmlDocument(targetFileContent);
+
+    const unitsPath = idPath.replace(new RegExp('/[^/]*/@id$'), '');
+    const targetFileItems = new Evaluator(targetFileDoc).evalNodeSet(unitsPath)[0];
+
+    const gather: XmlNode[] = [];
+    // Read all modules file
+    for (let moduleFilePath of moduleFilePaths) {
+       const fileContent = await readFileIfExists(moduleFilePath);
+        if (fileContent) {
+           const fromFileDoc = new XmlDocument(fileContent);
+           const moduleFileItems = new Evaluator(fromFileDoc).evalNodeSet(unitsPath)[0];
+           gather.push(...moduleFileItems.children);
+       }
+    }
+
+    targetFileItems.children = gather;
+    targetFileItems.firstChild = targetFileItems.children[0];
+    targetFileItems.lastChild = targetFileItems.children[targetFileItems.children.length - 1];
+
+    // retain xml declaration:
+    const xmlDecMatch = targetFileContent.match(/^<\?xml [^>]*>\s*/i);
+    const xmlDeclaration = xmlDecMatch ? xmlDecMatch[0] : '';
+
+    // we need to reformat the xml (whitespaces are messed up):
+    return xmlNormalize({
+        in: xmlDeclaration + targetFileDoc.toString({preserveWhitespace: true, compressed: true}),
+        trim: options.trim ?? false,
+        normalizeWhitespace: options.collapseWhitespace ?? true
+    });
+}
+
+/**
+ * This Builder allowed us to assemble all modules file and combine them to target file (message.en.xlf)
+ * @param options builder option - follow schema.json
+ * @param context builder context
+ */
+async function extractI18nAssembleBuilder(options: Options, context: BuilderContext): Promise<BuilderOutput> {
+    context.logger.info(`Running ng-extract-i18n-assemble for project ${context.target?.project}`);
+
+    if (!options.verbose) {
+        console.debug = () => null; // prevent debug output from xml_normalize and xliff-simple-merge
+    }
+    context.logger.debug(`options: ${JSON.stringify(options)}`);
+    const outputPath = options.outputPath as string || '.';
+    const format = options.format as string || 'xlf';
+    const isXliffV2 = format.includes('2');
+    const idPath = isXliffV2 ? '/xliff/file/unit/@id' : '/xliff/file/body/trans-unit/@id';
+
+    context.logger.info('running "assemble-i18n" ...');
+
+    // 1. Get list of all files in output folder
+    let files = getAllFileInDir(outputPath);
+    // 2. Remove files from list which are the same as sourceFile (message.xlf, message.en.xlf), Only keep the file in child's folder
+    files = files.filter(file => /\\/.test(file.substring(outputPath.length + 1)));
+    /* 2.Base on languages in targetFile, merge all children to the targetFile
+    Example: part_1.en.xlf => will merge to message.en.xlf
+             part_2.da.xlf => will merge to message.da.xlf */
+    for (let targetFile of options.targetFiles) {
+        targetFile = join(normalize(outputPath), targetFile);
+        const targetLocales = targetFile.match(/\S+\.([a-zA-Z]{2})\.xlf$/);
+        if (targetLocales && targetLocales[1]) {
+            const locale = targetLocales[1];
+            const moduleFiles = files.filter(file => file.endsWith(`.${locale}.xlf`));
+            const content = await mirgateModuleFileToTargetFile(moduleFiles, targetFile, idPath, options, context);
+            await fs.writeFile(targetFile, content);
+        }
+    }
+    context.logger.info('finished i18n assemble and normalizing');
+    return {success: true};
+}

--- a/src/fileUtils.ts
+++ b/src/fileUtils.ts
@@ -1,4 +1,5 @@
-import {promises as fs} from 'fs';
+import {promises as fs, readdirSync, statSync} from 'fs';
+import path from "path";
 
 export async function readFileIfExists(path: string): Promise<string | null> {
     try {
@@ -10,4 +11,17 @@ export async function readFileIfExists(path: string): Promise<string | null> {
         }
     }
     return null;
+}
+
+export function getAllFileInDir(directory: string) {
+    const _files: string[]  = [];
+    function throughDirectory(directory: string): void {
+        readdirSync(directory).forEach((file: string) => {
+            const absolutePath = path.join(directory, file);
+            if (statSync(absolutePath).isDirectory()) return throughDirectory(absolutePath);
+            else return _files.push(absolutePath);
+        });
+    }
+    throughDirectory(directory);
+    return _files;
 }

--- a/src/schema.json
+++ b/src/schema.json
@@ -23,6 +23,11 @@
       "description": "Translation source file. Path is assumed to be relative to 'outputPath'.",
       "default": "messages.xlf"
     },
+    "manageModules": {
+      "type": "boolean",
+      "default": false,
+      "description": "Divide translation files to multiple file base on id."
+    },
     "targetFiles": {
       "type": "array",
       "items": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                              /* Redirect output structure to the directory. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */


### PR DESCRIPTION
**Manage by module**

Assume this is an international project, and we need support in multiple languages. By then, the translation files had scaled up the size and were hard to manage. This is the translation management by modules that show its power.

`ng assemble-i18n`

In your project.json or angular.json, add `manageModules` and `assemble-i18n` if they are not exist

 ```
"assemble-i18n": {
      "executor": "ng-extract-i18n-merge:ng-extract-i18n-assemble",
      "options": {
        "browserTarget": "item-portal:build",
        "format": "xlf2",
        "outputPath": "src/assets/i18n",
        "sourceFile": "messages.xlf",
        "manageModules": true,
        "targetFiles": [
          "messages.en.xlf",
          "messages.da.xlf"
        ]
      }
    },
    "extract-i18n": {
      "executor": "ng-extract-i18n-merge:ng-extract-i18n-merge",
      "options": {
        "browserTarget": "item-portal:build",
        "format": "xlf2",
        "outputPath": "src/assets/i18n",
        "sourceFile": "messages.xlf",
        "manageModules": true,
        "targetFiles": [
          "messages.en.xlf",
          "messages.da.xlf"
        ]
      }
    },
```
When you run `nx extract-i18n`, based on your `@@moduleId_UnitId` For example: If the unit id in your HTML are `@@Frame_FrameDetails`, `@@Setting_Location` and `@@Common_Delete` you will got files like this

```
.
├── message.xlf
├── message.en.xlf
├── message.da.xlf
├── frame/
│   ├── frame.en.xlf
│   └── frame.da.xlf
├── setting/
│   ├── setting.en.xlf
│   └── setting.da.xlf
└── common/
    ├── common.en.xlf
    └── common.da.xlf
```
Send your parts to the translation department, then execute and combine them by the command to assemble only
`nx assemble-i18n`
Or `nx extract-i18n` to extract and assemble at the same time.

