### PR TITLE
When collapsing whitespace retain things like no-break space

### DIFF
--- a/src/builder.spec.ts
+++ b/src/builder.spec.ts
@@ -1444,7 +1444,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1465,7 +1465,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val </source>\n' +
+                        '        <source> source val\u00a0x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1474,8 +1474,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val </source>\n' +
-                        '        <target state="new"> source val </target>\n' +
+                        '        <source> source val\u00a0x </source>\n' +
+                        '        <target state="new"> source val\u00a0x </target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1491,7 +1491,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1512,7 +1512,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source>source val</source>\n' +
+                        '        <source>source val\u00a0x</source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1521,8 +1521,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source>source val</source>\n' +
-                        '        <target state="new">source val</target>\n' +
+                        '        <source>source val\u00a0x</source>\n' +
+                        '        <target state="new">source val\u00a0x</target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1587,7 +1587,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1607,7 +1607,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1616,8 +1616,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
-                        '        <target state="new"> source   val </target>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
+                        '        <target state="new"> source   val \u00a0 x </target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1633,7 +1633,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val </source>\n' +
+                        '        <source> source   val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1653,7 +1653,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val </source>\n' +
+                        '        <source> source val\u00a0x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1662,8 +1662,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val </source>\n' +
-                        '        <target state="new"> source val </target>\n' +
+                        '        <source> source val\u00a0x </source>\n' +
+                        '        <target state="new"> source val\u00a0x </target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +

--- a/src/builder.spec.ts
+++ b/src/builder.spec.ts
@@ -1444,7 +1444,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val \u00a0 x </source>\n' +
+                        '        <source> source   val   \u00a0   x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1465,7 +1465,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val\u00a0x </source>\n' +
+                        '        <source> source val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1474,8 +1474,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val\u00a0x </source>\n' +
-                        '        <target state="new"> source val\u00a0x </target>\n' +
+                        '        <source> source val \u00a0 x </source>\n' +
+                        '        <target state="new"> source val \u00a0 x </target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1491,7 +1491,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val \u00a0 x </source>\n' +
+                        '        <source> source   val  \u00a0  x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1512,7 +1512,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source>source val\u00a0x</source>\n' +
+                        '        <source>source val \u00a0 x</source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1521,8 +1521,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source>source val\u00a0x</source>\n' +
-                        '        <target state="new">source val\u00a0x</target>\n' +
+                        '        <source>source val \u00a0 x</source>\n' +
+                        '        <target state="new">source val \u00a0 x</target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1633,7 +1633,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source   val \u00a0 x </source>\n' +
+                        '        <source> source   val   \u00a0   x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1653,7 +1653,7 @@ describe('Builder', () => {
                         '  <file source-language="de" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val\u00a0x </source>\n' +
+                        '        <source> source val \u00a0 x </source>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +
@@ -1662,8 +1662,8 @@ describe('Builder', () => {
                         '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
                         '    <body>\n' +
                         '      <trans-unit id="ID1" datatype="html">\n' +
-                        '        <source> source val\u00a0x </source>\n' +
-                        '        <target state="new"> source val\u00a0x </target>\n' +
+                        '        <source> source val \u00a0 x </source>\n' +
+                        '        <target state="new"> source val \u00a0 x </target>\n' +
                         '      </trans-unit>\n' +
                         '    </body>\n' +
                         '  </file>\n' +

--- a/src/stringUtils.ts
+++ b/src/stringUtils.ts
@@ -1,3 +1,10 @@
+// Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space
 export function doCollapseWhitespace<T extends string | undefined>(destSourceText: T): T {
-    return destSourceText?.replace(/\s+/g, ' ') as T;
+    let result = destSourceText
+        ?.replace(/\t+/g, ' ')              // Convert tabs to spaces
+        ?.replace(/(\r\n|\n|\r)+/g, ' ')    // Collapse "sequences of segment breaks" to a single space (no need to preserve line-breaks)
+        ?.replace(/ *([^\S ]+) */g, '$1')   // Remove space before or after a "space-like" character that is not a space (e.g. no-break space).
+        ?.replace(/ {2,}/g, ' ');           // Collapse sequences of spaces to a single space
+
+    return result as T;
 }

--- a/src/stringUtils.ts
+++ b/src/stringUtils.ts
@@ -1,10 +1,7 @@
+// Converts sequences of space, tabs and "section breaks" like linefeeds and
+// carriage returns to a single space, but leaving other space characters like
+// no-break-space (U+00A0) intact.
 // Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space
 export function doCollapseWhitespace<T extends string | undefined>(destSourceText: T): T {
-    let result = destSourceText
-        ?.replace(/\t+/g, ' ')              // Convert tabs to spaces
-        ?.replace(/(\r\n|\n|\r)+/g, ' ')    // Collapse "sequences of segment breaks" to a single space (no need to preserve line-breaks)
-        ?.replace(/ *([^\S ]+) */g, '$1')   // Remove space before or after a "space-like" character that is not a space (e.g. no-break space).
-        ?.replace(/ {2,}/g, ' ');           // Collapse sequences of spaces to a single space
-
-    return result as T;
+    return destSourceText?.replace(/[\n\r\t ]+/g, ' ') as T;
 }


### PR DESCRIPTION
When the source code contains "special" space characters, such as no-break space (`\u00a0`), the current regex (`\s+`) replaces everything with a single space character (`\u0020`).

By following an approach that resembles more closely to the whitespace-collapsing implemented by browsers, this can be improved (see e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#collapsing_of_white_space).

This PR changes the `doCollapseWhitespace()` function to transform the input string in the following way:

1. Sequences of tab characters are replaced by a single space.
2. Sequences of segment breaks (here interpreted to be line breaks) are replaced by a single space.
3. Space characters before and after a "space-like but not space" character (e.g. no-break space `\u00a0` or zero-width-no-break-space `\ufeff`) are removed.
4. Sequences of space characters are collapsed to a single space.

Using this method, the source string `hello,  \u00a0 world !` becomes `hello,\u00a0world!` and when being displayed in the browser will _not_ break between `hello,` and `world!`.

The tests in `builder.spec.ts` have been extended to include strings with `\u00a0`.