### PR TITLE
Allow line number to be excluded from context

### DIFF
--- a/src/builder.spec.ts
+++ b/src/builder.spec.ts
@@ -1930,6 +1930,50 @@ describe('Builder', () => {
                 }
             );
         });
+        test('exclude line number context groups', async () => {
+            await runTest(
+                {
+                    messagesBefore: multipleContextGroupsDefaultMessages,
+                    messagesFrBefore: '<?xml version="1.0"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\n' +
+                        '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
+                        '    <body>\n' +
+                        '      <trans-unit id="ID1" datatype="html">\n' +
+                        '        <source>Some text</source>\n' +
+                        '        <target state="new">Some text</target>\n' +
+                        '        <context-group purpose="location">\n' +
+                        '          <context context-type="sourcefile">src/app/app-routing.module.ts</context>\n' +
+                        '          <context context-type="linenumber">12</context>\n' +
+                        '        </context-group>\n' +
+                        '      </trans-unit>\n' +
+                        '    </body>\n' +
+                        '  </file>\n' +
+                        '</xliff>',
+                    options: {
+                        format: 'xlf',
+                        targetFiles: ['messages.fr.xlf'],
+                        includeContext: true,
+                        excludeContextLineNumber: true,
+                        outputPath: 'builder-test'
+                    },
+                    messagesFrExpected: '<?xml version="1.0"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\n' +
+                        '  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">\n' +
+                        '    <body>\n' +
+                        '      <trans-unit id="ID1" datatype="html">\n' +
+                        '        <source>Some text</source>\n' +
+                        '        <target state="new">Some text</target>\n' +
+                        '        <context-group purpose="location">\n' +
+                        '          <context context-type="sourcefile">src/app/app-routing.module.ts</context>\n' +
+                        '        </context-group>\n' +
+                        '        <context-group purpose="location">\n' +
+                        '          <context context-type="sourcefile">src/app/app.component.html</context>\n' +
+                        '        </context-group>\n' +
+                        '      </trans-unit>\n' +
+                        '    </body>\n' +
+                        '  </file>\n' +
+                        '</xliff>'
+                }
+            );
+        });
         test('retain multiple context nodes', async () => {
 
             await runTest(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -3,7 +3,7 @@ import {basename, dirname, join, normalize} from '@angular-devkit/core';
 import {promises as fs} from 'fs';
 import {readFileIfExists} from './fileUtils';
 import {findLexClosestIndex} from './lexUtils';
-import {fromXlf1, fromXlf2, toXlf1, toXlf2} from './model/translationFileSerialization';
+import {ExportOptions, fromXlf1, fromXlf2, ImportOptions, toXlf1, toXlf2} from './model/translationFileSerialization';
 import {TranslationFile, TranslationUnit} from './model/translationFileModels';
 import {Merger} from './merger';
 import {Options} from './options';
@@ -81,13 +81,20 @@ async function extractI18nMergeBuilder(options: Options, context: BuilderContext
     function fromXlf(input: string): TranslationFile;
     function fromXlf(input: string | undefined | null): TranslationFile | undefined;
     function fromXlf(input: string | undefined | null): TranslationFile | undefined {
-        const inputOptions = { sortNestedTagAttributes: options.sortNestedTagAttributes ?? false };
+        const inputOptions: ImportOptions = {
+            sortNestedTagAttributes: options.sortNestedTagAttributes ?? false,
+            excludeContextLineNumber: options.excludeContextLineNumber ?? false
+        };
         return (input !== undefined && input !== null) ? (isXliffV2 ?
             fromXlf2(input, inputOptions) : fromXlf1(input, inputOptions)) : undefined;
     }
 
     function toXlf(output: TranslationFile): string {
-        const outputOptions = {prettyNestedTags: options.prettyNestedTags ?? false, selfClosingEmptyTargets: options.selfClosingEmptyTargets ?? true};
+        const outputOptions: ExportOptions = {
+            prettyNestedTags: options.prettyNestedTags ?? false,
+            selfClosingEmptyTargets: options.selfClosingEmptyTargets ?? true,
+            excludeContextLineNumber: options.excludeContextLineNumber ?? false
+        };
         return isXliffV2 ? toXlf2(output, outputOptions) : toXlf1(output, outputOptions);
     }
 

--- a/src/model/translationFileModels.ts
+++ b/src/model/translationFileModels.ts
@@ -1,6 +1,6 @@
-interface Location {
+export interface FileLocation {
     file: string;
-    lineStart: number;
+    lineStart?: number;
     lineEnd?: number;
 }
 
@@ -11,7 +11,7 @@ export interface TranslationUnit {
     state?: string;
     meaning?: string;
     description?: string;
-    locations: Location[];
+    locations: FileLocation[];
     additionalAttributes?: { name: string, value: string, path: string }[];
 }
 

--- a/src/model/translationFileSerialization.spec.ts
+++ b/src/model/translationFileSerialization.spec.ts
@@ -443,6 +443,35 @@ describe('translationFileSerialization', () => {
             }], 'de', 'fr-ch', '<?xml version="1.0" encoding="UTF-8"?>\n'));
         });
 
+        it('should handle no line numbers', () => {
+            const xlf1 = `<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="de" target-language="fr-ch" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="ID1" datatype="html">
+        <source>source val</source>
+        <target state="translated">target val</target>
+        <note priority="1" from="description">An introduction header for this sample</note>
+        <note priority="1" from="meaning">User welcome</note>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>`;
+            const translationFile = fromXlf1(xlf1, {excludeContextLineNumber: true});
+            expect(translationFile).toEqual(new TranslationFile([{
+                id: 'ID1',
+                source: 'source val',
+                target: 'target val',
+                state: 'translated',
+                meaning: 'User welcome',
+                description: 'An introduction header for this sample',
+                locations: [{file: 'app/app.component.ts'}]
+            }], 'de', 'fr-ch', '<?xml version="1.0" encoding="UTF-8"?>\n'));
+        });
+
         it('should parse additionalAttributes', () => {
             const xlf1 = `<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">

--- a/src/model/translationFileSerialization.ts
+++ b/src/model/translationFileSerialization.ts
@@ -1,5 +1,5 @@
 import {XmlDocument, XmlElement, XmlNode, XmlTextNode} from 'xmldoc';
-import {TranslationFile, TranslationUnit} from './translationFileModels';
+import {FileLocation, TranslationFile, TranslationUnit} from './translationFileModels';
 import {Options} from '../options';
 
 
@@ -23,8 +23,11 @@ const REGULAR_ATTRIBUTES_XLF2: {[nodeName: string]: string[]} = {
     'target': []
 }
 
+export type ImportOptions = Partial<Pick<Options, 'sortNestedTagAttributes' | 'excludeContextLineNumber'>>;
+export type ExportOptions = Partial<Pick<Options, 'prettyNestedTags' | 'selfClosingEmptyTargets' | 'excludeContextLineNumber'>>;
+
 export function fromXlf2(xlf2: string,
-    options: Pick<Options, 'sortNestedTagAttributes'> = { sortNestedTagAttributes: false }): TranslationFile {
+    options: ImportOptions = { sortNestedTagAttributes: false, excludeContextLineNumber: false }): TranslationFile {
 
     const doc = new XmlDocument(xlf2);
     const file = doc.childNamed('file')!;
@@ -67,7 +70,7 @@ function getTrailingWhitespace(xml: string): string | undefined {
 }
 
 export function fromXlf1(xlf1: string,
-    options: Pick<Options, 'sortNestedTagAttributes'> = { sortNestedTagAttributes: false }): TranslationFile {
+    options: ImportOptions = { sortNestedTagAttributes: false, excludeContextLineNumber: false }): TranslationFile {
 
     const doc = new XmlDocument(xlf1);
     const file = doc.childNamed('file')!;
@@ -85,10 +88,15 @@ export function fromXlf1(xlf1: string,
                 description:
                     toStringOrUndefined(options, notes?.find(note => note.attr.from === 'description')?.children),
                 locations: unit.childrenNamed('context-group')
-                    .map(contextGroup => ({
-                        file: contextGroup.childWithAttribute('context-type', 'sourcefile')!.val,
-                        lineStart: parseInt(contextGroup.childWithAttribute('context-type', 'linenumber')!.val, 10)
-                    })) ?? []
+                    .map(contextGroup => {
+                        let location: FileLocation = {
+                            file: contextGroup.childWithAttribute('context-type', 'sourcefile')!.val
+                        }
+                        if (!options.excludeContextLineNumber) {
+                            location.lineStart = parseInt(contextGroup.childWithAttribute('context-type', 'linenumber')!.val, 10)
+                        }
+                        return location;
+                    }) ?? []
             };
             const additionalAttributes = getAdditionalAttributes(unit, REGULAR_ATTRIBUTES_XLF1);
             if (additionalAttributes.length) {
@@ -99,7 +107,7 @@ export function fromXlf1(xlf1: string,
     return new TranslationFile(units, file.attr['source-language'], file.attr['target-language'], xlf1.match(XML_DECLARATION_MATCHER)?.[0], getTrailingWhitespace(xlf1));
 }
 
-function toString(options: Pick<Options, 'sortNestedTagAttributes'>, ...nodes: XmlNode[]): string {
+function toString(options: ImportOptions, ...nodes: XmlNode[]): string {
     return nodes.map(n => {
         if (options.sortNestedTagAttributes && n instanceof XmlElement) {
             const attr = Object.entries(n.attr).sort((a, b) => a[0].localeCompare(b[0]));
@@ -109,13 +117,13 @@ function toString(options: Pick<Options, 'sortNestedTagAttributes'>, ...nodes: X
     }).join('');
 }
 
-function toStringOrUndefined(options: Pick<Options, 'sortNestedTagAttributes'>, nodes: XmlNode[] | undefined):
+function toStringOrUndefined(options: ImportOptions, nodes: XmlNode[] | undefined):
     string | undefined {
 
     return nodes ? toString(options, ...nodes) : undefined;
 }
 
-export function toXlf2(translationFile: TranslationFile, options: Pick<Options, 'prettyNestedTags' | 'selfClosingEmptyTargets'>): string {
+export function toXlf2(translationFile: TranslationFile, options: ExportOptions): string {
     const doc = new XmlDocument(`<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="${translationFile.sourceLang}">
     <file id="ngi18n" original="ng.template">
     </file>
@@ -156,7 +164,7 @@ export function toXlf2(translationFile: TranslationFile, options: Pick<Options, 
     return (translationFile.xmlHeader ?? '') + pretty(doc, options) + (translationFile.trailingWhitespace ?? '');
 }
 
-export function toXlf1(translationFile: TranslationFile, options: Pick<Options, 'prettyNestedTags' | 'selfClosingEmptyTargets'>): string {
+export function toXlf1(translationFile: TranslationFile, options: ExportOptions): string {
     const doc = new XmlDocument(`<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file source-language="${translationFile.sourceLang}"  datatype="plaintext" original="ng2.template">
     <body></body>
@@ -192,10 +200,15 @@ export function toXlf1(translationFile: TranslationFile, options: Pick<Options, 
             transUnit.children.push(new XmlDocument(`<note priority="1" from="meaning">${unit.meaning}</note>`));
         }
         if (unit.locations.length) {
-            transUnit.children.push(...unit.locations.map(location => new XmlDocument(`<context-group purpose="location">
-            <context context-type="sourcefile">${location.file}</context>
-            <context context-type="linenumber">${location.lineStart}</context>
-        </context-group>`)));
+            transUnit.children.push(...unit.locations.map(location => {
+                let contextGroup = new XmlDocument(`<context-group purpose="location">
+                    <context context-type="sourcefile">${location.file}</context>
+                </context-group>`);
+                if (!options.excludeContextLineNumber) {
+                    contextGroup.children.push(new XmlDocument(`<context context-type="linenumber">${location.lineStart}</context>`))
+                }
+                return contextGroup;
+            }));
         }
         updateFirstAndLastChild(body);
         unit.additionalAttributes?.forEach(attr => {
@@ -232,7 +245,7 @@ function removeWhitespace<T extends XmlDocument | XmlElement>(node: T): void {
 }
 
 /// format with 2 spaces indentation, except for source/target nodes: there nested nodes are assured to keep (non-)whitespaces (potentially collapsed/expanded)
-function pretty(doc: XmlDocument, options: Pick<Options, 'prettyNestedTags' | 'selfClosingEmptyTargets'>) {
+function pretty(doc: XmlDocument, options: ExportOptions) {
     removeWhitespace(doc);
     addPrettyWhitespace(doc, 0, options);
     const s = doc.toString({preserveWhitespace: true, compressed: true});
@@ -252,7 +265,7 @@ function indentChildren(doc: XmlElement, indent: number) {
     updateFirstAndLastChild(doc);
 }
 
-function addPrettyWhitespace(doc: XmlElement, indent: number, options: Pick<Options, 'prettyNestedTags'>, sourceOrTarget = false) {
+function addPrettyWhitespace(doc: XmlElement, indent: number, options: ExportOptions, sourceOrTarget = false) {
     if (isSourceOrTarget(doc) || sourceOrTarget) {
         if (options.prettyNestedTags && doc.children.length && doc.children.every(c => isWhiteSpace(c) || c.type === 'element')) {
             doc.children = doc.children.filter(c => !isWhiteSpace(c));

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,7 @@ export interface Options extends JsonObject {
     collapseWhitespace: boolean,
     trim: boolean,
     includeContext: boolean | 'sourceFileOnly',
+    excludeContextLineNumber: boolean,
     includeMeaningAndDescription: boolean,
     newTranslationTargetsBlank: boolean | 'omit',
     sort: 'idAsc' | 'stableAppendNew' | 'stableAlphabetNew',

--- a/src/schema.json
+++ b/src/schema.json
@@ -120,6 +120,11 @@
       "default": false,
       "description": "Whether to include the context information (like notes) in the translation files. This is useful for sending the target translation files to translation agencies/services. When `sourceFileOnly` the context is retained only in the `sourceFile`."
     },
+    "excludeContextLineNumber": {
+      "type": "boolean",
+      "default": false,
+      "description": "If context is included exclude the line number and only include the file name"
+    },
     "includeMeaningAndDescription": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
Allow the line number to be excluded from the context.  This can help reduce noise in the committed xlf files for strings that have not changed but their line number was shifted due to other changes in the file.
