### PR TITLE
Add Angular 22 RC support by updating dependency ranges and CI matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,12 @@ jobs:
             node: {version: 22.x, types-version: 22.9.1}
           - angular: {version: 21.0.0-rc.1, devkit-version: 0.2100.0-rc.1}
             node: {version: 24.x, types-version: 22.9.1}
-
+          - angular: {version: 22.0.0-rc.0, devkit-version: 0.2200.0-rc.0}
+            node: {version: 20.19.0, types-version: 20.19.0}
+          - angular: {version: 22.0.0-rc.0, devkit-version: 0.2200.0-rc.0}
+            node: {version: 22.x, types-version: 22.9.1}
+          - angular: {version: 22.0.0-rc.0, devkit-version: 0.2200.0-rc.0}
+            node: {version: 24.x, types-version: 22.9.1}
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node.version }}

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   },
   "homepage": "https://github.com/daniel-sc/ng-extract-i18n-merge#readme",
   "dependencies": {
-    "@angular-devkit/architect": ">=0.2000.0 <0.2200.0",
-    "@angular-devkit/core": "^20.0.0 || ^21.0.0",
-    "@angular-devkit/schematics": "^20.0.0 || ^21.0.0",
-    "@schematics/angular": "^20.0.0 || ^21.0.0",
+    "@angular-devkit/architect": ">=0.2000.0 <0.2300.0",
+    "@angular-devkit/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
+    "@angular-devkit/schematics": "^20.0.0 || ^21.0.0 || ^22.0.0",
+    "@schematics/angular": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "xmldoc": "^1.1.3"
   },
   "peerDependencies": {
-    "@angular/build": "^20.0.0 || ^21.0.0"
+    "@angular/build": "^20.0.0 || ^21.0.0 || ^22.0.0"
   },
   "devDependencies": {
     "@types/babel__traverse": "<=7.20.4",


### PR DESCRIPTION
### Motivation
- Add compatibility for Angular 22 (release candidate) across the project and CI so the package can be built and tested against the upcoming Angular release. 
- Ensure devkit and schematics ranges accept the new 22.x artifacts to avoid installation conflicts. 
- Expand the CI matrix to validate the code with Angular 22 RC on multiple Node versions.

### Description
- Updated `.github/workflows/node.js.yml` to add Angular 22.0.0-rc.0 (devkit 0.2200.0-rc.0) to the GitHub Actions matrix for Node `20.19.0`, `22.x`, and `24.x` runs. 
- Broadened dependency ranges in `package.json` for `@angular-devkit/architect` to `>=0.2000.0 <0.2300.0` and added `^22.0.0` compatibility to `@angular-devkit/core`, `@angular-devkit/schematics`, and `@schematics/angular`. 
- Added `^22.0.0` to the `peerDependencies` entry for `@angular/build` so Angular 22 consumers are supported.

### Testing
- CI exercises the matrix jobs which run `npm i`, `npm run build`, and `npm run test-coverage` for each matrix entry. 
- Coveralls reporting is executed via the existing Coveralls GitHub Action step for each matrix job. 
- The automated build and test steps completed successfully for the updated matrix entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1173b4dd78832cbd69e0321644c226)