### PR TITLE
feat: support Angular 22 RC

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,12 +22,18 @@ jobs:
             node: {version: 22.x, types-version: 22.9.1}
           - angular: {version: 20.3.9, devkit-version: 0.2003.9}
             node: {version: 24.x, types-version: 22.9.1}
-          - angular: {version: 21.0.0-rc.1, devkit-version: 0.2100.0-rc.1}
+          - angular: {version: 21.0.0, devkit-version: 0.2100.0}
             node: {version: 20.19.0, types-version: 20.19.0}
-          - angular: {version: 21.0.0-rc.1, devkit-version: 0.2100.0-rc.1}
+          - angular: {version: 21.0.0, devkit-version: 0.2100.0}
             node: {version: 22.x, types-version: 22.9.1}
-          - angular: {version: 21.0.0-rc.1, devkit-version: 0.2100.0-rc.1}
+          - angular: {version: 21.0.0, devkit-version: 0.2100.0}
             node: {version: 24.x, types-version: 22.9.1}
+          - angular: {version: 22.0.0-rc.2, devkit-version: 0.2200.0-rc.2}
+            node: {version: 22.22.3, types-version: 22.19.19}
+          - angular: {version: 22.0.0-rc.2, devkit-version: 0.2200.0-rc.2}
+            node: {version: 24.15.0, types-version: 24.12.4}
+          - angular: {version: 22.0.0-rc.2, devkit-version: 0.2200.0-rc.2}
+            node: {version: 26.x, types-version: 25.9.1}
 
     steps:
     - uses: actions/checkout@v4

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,9 @@ const config: JestConfigWithTsJest = {
     verbose: false,
     testMatch: undefined,
     testRegex: '.*\.spec\.ts$',
+    moduleNameMapper: {
+        '^ora$': '<rootDir>/jest.ora.stub.js',
+    },
     collectCoverageFrom: ['src/**/*.ts'], // exclude coverage from schematic as it only collects from js (instead of ts)..
 };
 export default config;

--- a/jest.ora.stub.js
+++ b/jest.ora.stub.js
@@ -1,0 +1,22 @@
+// Angular 22's schematics test utilities load `ora`, which is ESM-only.
+// This project runs Jest through ts-jest in CommonJS mode, so Jest cannot
+// parse the real `ora` package and fails before schematic tests execute.
+// The Jest config maps `ora` to this minimal spinner stub for tests only.
+// Runtime/published code still uses Angular DevKit's real dependencies.
+module.exports = function ora() {
+    return {
+        start() {
+            return this;
+        },
+        succeed() {
+            return this;
+        },
+        fail() {
+            return this;
+        },
+        stop() {
+            return this;
+        },
+    };
+};
+module.exports.default = module.exports;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": ">=0.2000.0 <0.2200.0",
-        "@angular-devkit/core": "^20.0.0 || ^21.0.0",
-        "@angular-devkit/schematics": "^20.0.0 || ^21.0.0",
-        "@schematics/angular": "^20.0.0 || ^21.0.0",
+        "@angular-devkit/architect": ">=0.2000.0 <0.2200.0 || >=0.2200.0-rc.0 <0.2300.0",
+        "@angular-devkit/core": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
+        "@angular-devkit/schematics": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
+        "@schematics/angular": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
         "xmldoc": "^1.1.3"
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
         "@types/jest": "^28.1.8 || ^29.0.0",
         "@types/xmldoc": "^1.1.6",
         "jest": "^28.0.8 || ^29.0.0",
-        "ts-jest": "^28.0.8 || >=29.0.0 <29.3.0",
+        "ts-jest": "^28.0.8 || >=29.0.0 <29.3.0 || >=29.4.7 <30.0.0",
         "ts-node": ">=10.9.1",
         "typescript": ">=5.8.0"
       },
@@ -28,7 +28,7 @@
         "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@angular/build": "^20.0.0 || ^21.0.0"
+        "@angular/build": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -35,21 +35,21 @@
   },
   "homepage": "https://github.com/daniel-sc/ng-extract-i18n-merge#readme",
   "dependencies": {
-    "@angular-devkit/architect": ">=0.2000.0 <0.2200.0",
-    "@angular-devkit/core": "^20.0.0 || ^21.0.0",
-    "@angular-devkit/schematics": "^20.0.0 || ^21.0.0",
-    "@schematics/angular": "^20.0.0 || ^21.0.0",
+    "@angular-devkit/architect": ">=0.2000.0 <0.2200.0 || >=0.2200.0-rc.0 <0.2300.0",
+    "@angular-devkit/core": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
+    "@angular-devkit/schematics": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
+    "@schematics/angular": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0",
     "xmldoc": "^1.1.3"
   },
   "peerDependencies": {
-    "@angular/build": "^20.0.0 || ^21.0.0"
+    "@angular/build": "^20.0.0 || ^21.0.0 || ^22.0.0-rc.0"
   },
   "devDependencies": {
     "@types/babel__traverse": "<=7.20.4",
     "@types/jest": "^28.1.8 || ^29.0.0",
     "@types/xmldoc": "^1.1.6",
     "jest": "^28.0.8 || ^29.0.0",
-    "ts-jest": "^28.0.8 || >=29.0.0 <29.3.0",
+    "ts-jest": "^28.0.8 || >=29.0.0 <29.3.0 || >=29.4.7 <30.0.0",
     "ts-node": ">=10.9.1",
     "typescript": ">=5.8.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "types": ["jest", "node"],                    /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- add Angular 22 RC peer/dependency support
- add Angular 22 RC CI matrix entries
- configure Jest to stub ESM-only ora for schematic tests

## Validation
- npm exec tsc -- --noEmit
- npm test -- --runTestsByPath schematics/ng-add/index.spec.ts --runInBand
- git diff --check

Closes #155